### PR TITLE
fix(ansible): Adding powercycle tasks in bios.yml

### DIFF
--- a/ansible/bios.yml
+++ b/ansible/bios.yml
@@ -32,6 +32,10 @@
 
     # TODO: configre BIOS to be always on ( see lab/hardware/dh123) and any virtualization or hyper threading settings we might need
 
+    - name: Debug print bios attributes
+      ansible.builtin.debug: msg={{ result.redfish_facts.bios_attribute.entries[0][1].SystemManufacturer }}
+      when: result.redfish_facts.bios_attribute.entries[0][1].SystemManufacturer is defined
+
     # Updating Bios attributes in host BMCs
     - name: Set BIOS attributes
       community.general.redfish_config:
@@ -43,25 +47,45 @@
        username: "{{ ansible_user }}"
        password: "{{ ansible_password }}"
       register: bios_attribute
-      tags: ["TEST"]
 
-    # DELL ONLY: Updating BIOS settings requires creating a configuration job
+    # DELL iDRAC ONLY: Updating BIOS settings requires creating a configuration job
     # to schedule the BIOS update, so comment out below for non-Dell systems.
 
-#    - name: Create BIOS configuration job (schedule BIOS setting update)
-#      community.general.idrac_redfish_command:
-#       category: Systems
-#       command: CreateBiosConfigJob
-#       baseuri: "{{ ansible_host }}"
-#       username: "{{ ansible_user }}"
-#       password: "{{ ansible_password }}"
-#      when: bios_attribute.changed
+    - name: Create BIOS configuration job (schedule BIOS setting update)
+      when: 
+        - result.redfish_facts.bios_attribute.entries[0][1].SystemManufacturer is defined 
+        - result.redfish_facts.bios_attribute.entries[0][1].SystemManufacturer == "Dell Inc." 
+        - bios_attribute.changed
+      community.general.idrac_redfish_command:
+       category: Systems
+       command: CreateBiosConfigJob
+       baseuri: "{{ ansible_host }}"
+       username: "{{ ansible_user }}"
+       password: "{{ ansible_password }}"
+      register: bios_config_job
 
-#    - name: Reboot system to apply new BIOS settings
-#      community.general.redfish_command:
-#       category: Systems
-#       command: PowerReboot
-#       baseuri: "{{ ansible_host }}"
-#       username: "{{ ansible_user }}"
-#       password: "{{ ansible_password }}"
-#      when: bios_attribute.changed
+    - name: Reboot iDRAC systems to apply new BIOS settings
+      when: 
+        - result.redfish_facts.bios_attribute.entries[0][1].SystemManufacturer is defined 
+        - result.redfish_facts.bios_attribute.entries[0][1].SystemManufacturer == "Dell Inc." 
+        - bios_config_job.changed
+      community.general.redfish_command:
+       category: Systems
+       command: PowerReboot
+       resource_id: "{{ resource_id }}"
+       baseuri: "{{ ansible_host }}"
+       username: "{{ ansible_user }}"
+       password: "{{ ansible_password }}"
+
+    # TODO: Merge two reboot tasks into one. find identifier for iLO in redfish bios attributes 
+    - name: Reboot iLO systems to apply new BIOS settings
+      when: 
+        - bios_attribute.changed
+        - inventory_hostname == 'dh2bmc' or inventory_hostname == 'dh3bmc'
+      community.general.redfish_command:
+       category: Systems
+       command: PowerReboot
+       resource_id: "{{ resource_id }}"
+       baseuri: "{{ ansible_host }}"
+       username: "{{ ansible_user }}"
+       password: "{{ ansible_password }}"

--- a/ansible/inventory
+++ b/ansible/inventory
@@ -7,10 +7,10 @@ dh3 ansible_host=172.22.1.3     ansible_connection=ssh        ansible_user=root
 dh4 ansible_host=172.22.1.4     ansible_connection=ssh        ansible_user=root
 
 [hostbmcs]
-dh1bmc ansible_host=172.22.2.1  ansible_connection=local      ansible_user=root          resource_id=System.Embedded.1 bios_attributes="{'AcPwrRcvry': 'On', 'AcPwrRcvryDelay': 'Immediate', 'AcPwrRcvryUserDelay': '10'}"
+dh1bmc ansible_host=172.22.2.1  ansible_connection=local      ansible_user=root          resource_id=System.Embedded.1 bios_attributes="{'AcPwrRcvry': 'On', 'AcPwrRcvryDelay': 'Immediate', 'AcPwrRcvryUserDelay': 120}"
 dh2bmc ansible_host=172.22.2.2  ansible_connection=local      ansible_user=Administrator resource_id=1 bios_attributes="{'AutoPowerOn': 'AlwaysPowerOn','PowerOnDelay': 'NoDelay'}"
 dh3bmc ansible_host=172.22.2.3  ansible_connection=local      ansible_user=Administrator resource_id=1 bios_attributes="{'PowerOnDelay': 'NoDelay'}"
-dh4bmc ansible_host=172.22.2.4  ansible_connection=local      ansible_user=root          resource_id=System.Embedded.1 bios_attributes="{'AcPwrRcvry': 'On', 'AcPwrRcvryDelay': 'Immediate', 'AcPwrRcvryUserDelay': '10'}"
+dh4bmc ansible_host=172.22.2.4  ansible_connection=local      ansible_user=root          resource_id=System.Embedded.1 bios_attributes="{'AcPwrRcvry': 'On', 'AcPwrRcvryDelay': 'Immediate', 'AcPwrRcvryUserDelay': 120}"
 
 
 [DPUs]


### PR DESCRIPTION
Pending TODO: To merge powercycle tasks for iDRAC and iLO into one or figure out identifier for iLO from bios attributes.  