### PR TITLE
fix(sztp): correct or disable shellcheck errors in working scripts

### DIFF
--- a/sztp/generate.sh
+++ b/sztp/generate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
-# shellcheck disable=SC2046,SC2034,SC2016
+# shellcheck disable=SC2034
 
 set -euo pipefail
 
@@ -9,12 +9,12 @@ declare -a names
 for vendor in nvidia intel marvell amd
 do
     names+=("${vendor^^}_BOOT_IMG_HASH_VAL" "${vendor^^}_CONFIG_B64")
-    export ${vendor^^}_BOOT_IMG_HASH_VAL=$(openssl dgst -sha256 -c  ./images/${vendor,,}-boot-image.img | awk '{print $2}')
-    export ${vendor^^}_CONFIG_B64=$(openssl enc -base64 -A -in      ./config/${vendor,,}-configuration.xml)
+    export ${vendor^^}_BOOT_IMG_HASH_VAL="$(openssl dgst -sha256 -c  ./images/${vendor,,}-boot-image.img | awk '{print $2}')"
+    export ${vendor^^}_CONFIG_B64="$(openssl enc -base64 -A -in      ./config/${vendor,,}-configuration.xml)"
     for item in pre post
     do
         names+=("${vendor^^}_${item^^}_SCRIPT_B64")
-        export ${vendor^^}_${item^^}_SCRIPT_B64=$(openssl enc -base64 -A -in  ./config/${vendor,,}-${item,,}-configuration-script.sh)
+        export ${vendor^^}_${item^^}_SCRIPT_B64="$(openssl enc -base64 -A -in  ./config/${vendor,,}-${item,,}-configuration-script.sh)"
     done
 done
 
@@ -34,6 +34,7 @@ SZTPD_SBI_PORT=$(awk '/SZTPD_SBI_PORT:/{print $2}' ../docker-compose.yml)
 
 # generate template
 export "${names[@]}"
+# shellcheck disable=SC2016
 envsubst "$(printf '${%s} ' "${names[@]}")" < template.json > generated_config.json
 
 # check what changed

--- a/sztp/generate.sh
+++ b/sztp/generate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
-# shellcheck disable=SC2046,SC2034,SC2068,SC2016
+# shellcheck disable=SC2046,SC2034,SC2016
 
 set -euo pipefail
 
@@ -34,7 +34,7 @@ SZTPD_SBI_PORT=$(awk '/SZTPD_SBI_PORT:/{print $2}' ../docker-compose.yml)
 
 # generate template
 export "${names[@]}"
-envsubst "$(printf '${%s} ' ${names[@]})" < template.json > generated_config.json
+envsubst "$(printf '${%s} ' "${names[@]}")" < template.json > generated_config.json
 
 # check what changed
 diff template.json generated_config.json || true

--- a/sztp/generate.sh
+++ b/sztp/generate.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+# shellcheck disable=SC2046,SC2034,SC2068
 
 set -euo pipefail
 

--- a/sztp/generate.sh
+++ b/sztp/generate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
-# shellcheck disable=SC2046,SC2034,SC2068
+# shellcheck disable=SC2046,SC2034,SC2068,SC2016
 
 set -euo pipefail
 

--- a/sztp/key.sh
+++ b/sztp/key.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/bash
-# shellcheck disable=SC2129
 
 set -euo pipefail
 
@@ -9,9 +8,11 @@ trap 'rm -rf -- "$MYTMPDIR"' EXIT
 curl -kL https://watsen.net/support/sztpd-simulator-0.0.11.tgz | tar -zxvf - -C "${MYTMPDIR}"/
 pushd "${MYTMPDIR}"/sztpd-simulator/pki
 # SBI Port certificates
-echo "DNS.2 = bootstrap" >> sztpd1/sbi/end-entity/openssl.cnf
-echo "DNS.3 = web" >> sztpd1/sbi/end-entity/openssl.cnf
-echo "DNS.4 = redirecter" >> sztpd1/sbi/end-entity/openssl.cnf
+{
+    echo "DNS.2 = bootstrap"
+    echo "DNS.3 = web"
+    echo "DNS.4 = redirecter"
+} >> sztpd1/sbi/end-entity/openssl.cnf
 make -C sztpd1/sbi pki
 cat sztpd1/sbi/end-entity/my_cert.pem sztpd1/sbi/intermediate2/my_cert.pem > "${MYTMPDIR}"/sztpd-simulator/cert_chain.pem
 openssl crl2pkcs7 -nocrl -certfile "${MYTMPDIR}"/sztpd-simulator/cert_chain.pem -outform DER -out "${MYTMPDIR}"/sztpd-simulator/cert_chain.cms

--- a/sztp/key.sh
+++ b/sztp/key.sh
@@ -1,48 +1,48 @@
 #!/usr/bin/bash
-# shellcheck disable=SC2086,SC2129
+# shellcheck disable=SC2129
 
 set -euo pipefail
 
 MYTMPDIR="$(mktemp -d)"
 trap 'rm -rf -- "$MYTMPDIR"' EXIT
 
-curl -kL https://watsen.net/support/sztpd-simulator-0.0.11.tgz | tar -zxvf - -C ${MYTMPDIR}/
-pushd ${MYTMPDIR}/sztpd-simulator/pki
+curl -kL https://watsen.net/support/sztpd-simulator-0.0.11.tgz | tar -zxvf - -C "${MYTMPDIR}"/
+pushd "${MYTMPDIR}"/sztpd-simulator/pki
 # SBI Port certificates
 echo "DNS.2 = bootstrap" >> sztpd1/sbi/end-entity/openssl.cnf
 echo "DNS.3 = web" >> sztpd1/sbi/end-entity/openssl.cnf
 echo "DNS.4 = redirecter" >> sztpd1/sbi/end-entity/openssl.cnf
 make -C sztpd1/sbi pki
-cat sztpd1/sbi/end-entity/my_cert.pem sztpd1/sbi/intermediate2/my_cert.pem > ${MYTMPDIR}/sztpd-simulator/cert_chain.pem
-openssl crl2pkcs7 -nocrl -certfile ${MYTMPDIR}/sztpd-simulator/cert_chain.pem -outform DER -out ${MYTMPDIR}/sztpd-simulator/cert_chain.cms
+cat sztpd1/sbi/end-entity/my_cert.pem sztpd1/sbi/intermediate2/my_cert.pem > "${MYTMPDIR}"/sztpd-simulator/cert_chain.pem
+openssl crl2pkcs7 -nocrl -certfile "${MYTMPDIR}"/sztpd-simulator/cert_chain.pem -outform DER -out "${MYTMPDIR}"/sztpd-simulator/cert_chain.cms
 # client cert DevID trust anchors
 make -C client pki
-cat client/root-ca/my_cert.pem client/intermediate1/my_cert.pem client/intermediate2/my_cert.pem > ${MYTMPDIR}/sztpd-simulator/ta_cert_chain.pem
-openssl crl2pkcs7 -nocrl -certfile ${MYTMPDIR}/sztpd-simulator/ta_cert_chain.pem -outform DER -out ${MYTMPDIR}/sztpd-simulator/ta_cert_chain.cms
+cat client/root-ca/my_cert.pem client/intermediate1/my_cert.pem client/intermediate2/my_cert.pem > "${MYTMPDIR}"/sztpd-simulator/ta_cert_chain.pem
+openssl crl2pkcs7 -nocrl -certfile "${MYTMPDIR}"/sztpd-simulator/ta_cert_chain.pem -outform DER -out "${MYTMPDIR}"/sztpd-simulator/ta_cert_chain.cms
 # ???
-cat sztpd1/sbi/root-ca/my_cert.pem sztpd1/sbi/intermediate1/my_cert.pem > ${MYTMPDIR}/sztpd-simulator/opi.pem
+cat sztpd1/sbi/root-ca/my_cert.pem sztpd1/sbi/intermediate1/my_cert.pem > "${MYTMPDIR}"/sztpd-simulator/opi.pem
 popd
 
 # copy locally for server
 rm -rf ./generated-server
 mkdir -p ./generated-server
-cp ${MYTMPDIR}/sztpd-simulator/pki/sztpd1/sbi/end-entity/*.pem ./generated-server/
-cp ${MYTMPDIR}/sztpd-simulator/pki/sztpd1/sbi/end-entity/{private,public}_key.der ./generated-server/
-cp ${MYTMPDIR}/sztpd-simulator/cert_chain.{pem,cms} ./generated-server/
-cp ${MYTMPDIR}/sztpd-simulator/ta_cert_chain.{pem,cms} ./generated-server/
+cp "${MYTMPDIR}"/sztpd-simulator/pki/sztpd1/sbi/end-entity/*.pem ./generated-server/
+cp "${MYTMPDIR}"/sztpd-simulator/pki/sztpd1/sbi/end-entity/{private,public}_key.der ./generated-server/
+cp "${MYTMPDIR}"/sztpd-simulator/cert_chain.{pem,cms} ./generated-server/
+cp "${MYTMPDIR}"/sztpd-simulator/ta_cert_chain.{pem,cms} ./generated-server/
 chmod -R a+r ./generated-server
 
 # copy remotely for clients
 rm -rf ./generated-client
 mkdir -p ./generated-client
-cp ${MYTMPDIR}/sztpd-simulator/opi.pem ./generated-client/opi.pem
+cp "${MYTMPDIR}"/sztpd-simulator/opi.pem ./generated-client/opi.pem
 for vendor in nvidia intel marvell amd; do
-    sed -i "s/my-serial-number/${vendor}-serial-number/g" ${MYTMPDIR}/sztpd-simulator/pki/client/end-entity/openssl.cnf
-    make -C ${MYTMPDIR}/sztpd-simulator/pki/client/end-entity    cert_request      OPENSSL=openssl
-    make -C ${MYTMPDIR}/sztpd-simulator/pki/client/intermediate2 sign_cert_request OPENSSL=openssl REQDIR="../end-entity"
-    cp ${MYTMPDIR}/sztpd-simulator/pki/client/end-entity/private_key.pem ./generated-client/${vendor}_private_key.pem
-    cp ${MYTMPDIR}/sztpd-simulator/pki/client/end-entity/my_cert.pem ./generated-client/${vendor}_my_cert.pem
-    sed -i "s/${vendor}-serial-number/my-serial-number/g" ${MYTMPDIR}/sztpd-simulator/pki/client/end-entity/openssl.cnf
+    sed -i "s/my-serial-number/${vendor}-serial-number/g" "${MYTMPDIR}"/sztpd-simulator/pki/client/end-entity/openssl.cnf
+    make -C "${MYTMPDIR}"/sztpd-simulator/pki/client/end-entity    cert_request      OPENSSL=openssl
+    make -C "${MYTMPDIR}"/sztpd-simulator/pki/client/intermediate2 sign_cert_request OPENSSL=openssl REQDIR="../end-entity"
+    cp "${MYTMPDIR}"/sztpd-simulator/pki/client/end-entity/private_key.pem ./generated-client/${vendor}_private_key.pem
+    cp "${MYTMPDIR}"/sztpd-simulator/pki/client/end-entity/my_cert.pem ./generated-client/${vendor}_my_cert.pem
+    sed -i "s/${vendor}-serial-number/my-serial-number/g" "${MYTMPDIR}"/sztpd-simulator/pki/client/end-entity/openssl.cnf
 done
 chmod -R a+r ./generated-client
 

--- a/sztp/key.sh
+++ b/sztp/key.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+# shellcheck disable=SC2086,SC2129
 
 set -euo pipefail
 


### PR DESCRIPTION
shellcheck is reporting errors on scripts that are working.  The scripts pass in their operation when run on the target platform/environment.

To allow the CI checking of the script to pass, the errors are disabled at the top of the script files.

This allows the shellcheck lint to pass, given that the errors reported in some cases are not generic errors and can be correct syntax in the shell script.