### PR TITLE
Fixed the naming convention for additional mounts

### DIFF
--- a/ansible/monitoring.yml
+++ b/ansible/monitoring.yml
@@ -47,7 +47,7 @@
             state: started
             name: spdk_tgt
 
-        - name: Add additional mount for bf2
+        - name: Nvidia | Add additional mount for bf2
           ansible.builtin.set_fact:
             telegraf_mounts: "{{ telegraf_mounts + [{'type': 'bind', 'source': '/run/emu_param', 'target': '/run/emu_param', 'read_only': true}] }}"
 


### PR DESCRIPTION
fix(monitoring): fixed the naming convention for additional mounts