### PR TITLE
fix(mev): add temperature

### DIFF
--- a/ansible/monitoring.yml
+++ b/ansible/monitoring.yml
@@ -60,6 +60,16 @@
             name: requests
             version: "<2.32"
 
+        - name: Intel | Set cron job to get imc temperature every 5 minutes
+          ansible.builtin.cron:
+            name: "mev imc temperature"
+            minute: "*/5"
+            job: "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 root@192.168.0.1 iset-cli get-temperature > /run/mev_imc_temperature.json"
+
+        - name: Intel | Add additional mount for mev
+          ansible.builtin.set_fact:
+            telegraf_mounts: "{{ telegraf_mounts + [{'type': 'bind', 'source': '/run/mev_imc_temperature.json', 'target': '/run/mev_imc_temperature.json', 'read_only': true}] }}"
+
     - name: Print the list of mounts for each host
       ansible.builtin.debug:
         var: telegraf_mounts

--- a/telegraf.d/telegraf.conf.mev
+++ b/telegraf.d/telegraf.conf.mev
@@ -10,10 +10,10 @@
 [[inputs.nstat]]
   # no configuration
 
-#[[inputs.exec]]
-#  commands = ["ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 root@192.168.0.1 iset-cli get-temperature"]
-#  name_override = "temp"
-#  data_format = "json"
+[[inputs.file]]
+  files = ["/run/mev_imc_temperature.json"]
+  name_override = "temp"
+  data_format = "json"
 
 [[outputs.file]]
   files = ["stdout"]


### PR DESCRIPTION
test new temperature appears on http://172.22.0.1:8889/metrics

example output:
```
[root@ipu-acc ~]# ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 root@192.168.0.1 iset-cli get-temperature
Warning: Permanently added '192.168.0.1' (ED25519) to the list of known hosts.
{
        "Result":"Success",
        "Virtual Temperature Sensor (C)":52,
        "ASIC Sensor 0 (C)":41,
        "ASIC Sensor 1 (C)":40,
        "ASIC Sensor 2 (C)":41,
        "ASIC Sensor 3 (C)":40,
        "ASIC Sensor 4 (C)":40,
        "ASIC Sensor 5 (C)":39,
        "ASIC Sensor 6 (C)":44,
        "ASIC Sensor 7 (C)":41,
        "ASIC Sensor 8 (C)":42,
        "ASIC Sensor 9 (C)":40,
        "ASIC Sensor 10 (C)":40,
        "ASIC Sensor 11 (C)":40,
        "ASIC Sensor 12 (C)":41,
        "ASIC Sensor 13 (C)":41,
        "ASIC Sensor 14 (C)":42,
        "ASIC Sensor 15 (C)":41,
        "Board Back Edge Ambient (C)":29,
        "Board Faceplate Ambient (C)":33,
        "Board Backside Ambient (C)":33,
        "ACC Core Thermal Diode (C)":42,
        "Phy Quad 0 (C)":37
}
```

from telegraf logs:

```
temp,host=c20368297a1a ASIC\ Sensor\ 8\ (C)=42,ASIC\ Sensor\ 9\ (C)=40,Board\ Back\ Edge\ Ambient\ (C)=29,ASIC\ Sensor\ 2\ (C)=41,ASIC\ Sensor\ 12\ (C)=41,ASIC\ Sensor\ 6\ (C)=44,ASIC\ Sensor\ 7\ (C)=41,ASIC\ Sensor\ 15\ (C)=41,Board\ Backside\ Ambient\ (C)=33,Phy\ Quad\ 0\ (C)=37,Board\ Faceplate\ Ambient\ (C)=33,ASIC\ Sensor\ 11\ (C)=40,ASIC\ Sensor\ 1\ (C)=40,ASIC\ Sensor\ 0\ (C)=41,ASIC\ Sensor\ 13\ (C)=40,ACC\ Core\ Thermal\ Diode\ (C)=42,ASIC\ Sensor\ 4\ (C)=40,ASIC\ Sensor\ 10\ (C)=40,ASIC\ Sensor\ 14\ (C)=42,Virtual\ Temperature\ Sensor\ (C)=52,ASIC\ Sensor\ 5\ (C)=39,ASIC\ Sensor\ 3\ (C)=40 1728601700000000000
```