### PR TITLE
adding more metrics for mev

### DIFF
--- a/ansible/monitoring.yml
+++ b/ansible/monitoring.yml
@@ -69,12 +69,23 @@
               -o ConnectTimeout=3 root@192.168.0.1 iset-cli get-temperature
               > /run/mev_imc_temperature.json
 
+        - name: Intel | Set Docker socket has appropriate permissions
+          ansible.builtin.file:
+            path: /var/run/docker.sock
+            mode: '0666'      
+
         - name: Intel | Add additional mount for mev
           ansible.builtin.set_fact:
-            telegraf_mounts: "{{ telegraf_mounts + [{'type': 'bind',
-              'source': '/run/mev_imc_temperature.json',
-              'target': '/run/mev_imc_temperature.json',
-              'read_only': true}] }}"
+            telegraf_mounts: "{{ telegraf_mounts + [
+              {'type': 'bind',
+               'source': '/run/mev_imc_temperature.json',
+               'target': '/run/mev_imc_temperature.json',
+               'read_only': true},
+              {'type': 'bind',
+               'source': '/var/run/docker.sock',
+               'target': '/var/run/docker.sock',
+               'read_only': false}
+             ] }}"
 
     - name: Print the list of mounts for each host
       ansible.builtin.debug:

--- a/ansible/monitoring.yml
+++ b/ansible/monitoring.yml
@@ -72,20 +72,18 @@
         - name: Intel | Set Docker socket has appropriate permissions
           ansible.builtin.file:
             path: /var/run/docker.sock
-            mode: '0666'      
+            mode: '0666'
 
         - name: Intel | Add additional mount for mev
           ansible.builtin.set_fact:
-            telegraf_mounts: "{{ telegraf_mounts + [
-              {'type': 'bind',
+            telegraf_mounts: "{{ telegraf_mounts + [{'type': 'bind',
                'source': '/run/mev_imc_temperature.json',
                'target': '/run/mev_imc_temperature.json',
                'read_only': true},
               {'type': 'bind',
                'source': '/var/run/docker.sock',
                'target': '/var/run/docker.sock',
-               'read_only': false}
-             ] }}"
+               'read_only': true}] }}"
 
     - name: Print the list of mounts for each host
       ansible.builtin.debug:

--- a/telegraf.d/telegraf.conf.mev
+++ b/telegraf.d/telegraf.conf.mev
@@ -10,22 +10,37 @@
 [[inputs.nstat]]
   # no configuration
 
+# Diskio Input Plugin
 [[inputs.diskio]]
 
+# Disk Input Plugin
 [[inputs.disk]]
 
-[[inputs.netstat]]
-
-[[inputs.docker]]
-
+# Swap Input Plugin
 [[inputs.swap]]
 
+# System Input Plugin
 [[inputs.system]]
 
+# Net Input Plugin
 [[inputs.net]]
 
+# Netstat Input Plugin
+[[inputs.netstat]]
+
+# Kernel Input Plugin
 [[inputs.kernel]]
 
+# Internal Input Plugin
+[[inputs.internal]]
+
+# Processes Input Plugin
+[[inputs.processes]]
+
+# Docker Input Plugin
+[[inputs.docker]]
+
+# For temperature
 [[inputs.file]]
   files = ["/run/mev_imc_temperature.json"]
   name_override = "temp"

--- a/telegraf.d/telegraf.conf.mev
+++ b/telegraf.d/telegraf.conf.mev
@@ -10,6 +10,22 @@
 [[inputs.nstat]]
   # no configuration
 
+[[inputs.diskio]]
+
+[[inputs.disk]]
+
+[[inputs.netstat]]
+
+[[inputs.docker]]
+
+[[inputs.swap]]
+
+[[inputs.system]]
+
+[[inputs.net]]
+
+[[inputs.kernel]]
+
 [[inputs.file]]
   files = ["/run/mev_imc_temperature.json"]
   name_override = "temp"


### PR DESCRIPTION
```disk,device=tmpfs,fstype=tmpfs,host=ipu-acc,mode=rw,path=/proc/kcore total=67108864i,free=67108864i,used=0i,used_percent=0,inodes_total=1978647i,inodes_free=1978631i,inodes_used=16i,inodes_used_percent=0.0008086333742198582 1732415010000000000
swap,host=ipu-acc free=0i,used_percent=0,total=0i,used=0i 1732415010000000000
net,host=ipu-acc,interface=enp0s1f0 packets_recv=20693830i,err_in=0i,err_out=0i,drop_in=290i,drop_out=17597i,bytes_sent=59356099835i,bytes_recv=3275278876i,packets_sent=58810962i 1732415000000000000
system,host=ipu-acc uptime_format="137 days, 17:16" 1732414990000000000
diskio,host=ipu-acc,name=sda io_time=50416610i,reads=19388i,read_bytes=926258176i,write_time=38212498i,weighted_io_time=69565724i,iops_in_progress=0i,merged_reads=2879i,merged_writes=5145237i,writes=5305705i,write_bytes=52769894400i,read_time=21248i 1732415010000000000
kernel,host=ipu-acc entropy_avail=256i,interrupts=1017692048i,context_switches=1668075543i,boot_time=1720516001i,processes_forked=782011i 1732415240000000000
netstat,host=ipu-acc tcp_syn_sent=0i,tcp_fin_wait2=0i,tcp_time_wait=0i,tcp_close_wait=0i,tcp_last_ack=0i,tcp_none=24i,udp_socket=7i,tcp_established=2i,tcp_syn_recv=0i,tcp_fin_wait1=0i,tcp_close=0i,tcp_listen=4i,tcp_closing=0i 1732415240000000000
docker_container_mem,container_image=telegraf,container_name=test,container_status=running,container_version=1.29,engine_host=ipu-acc,host=ipu-acc,server_version=27.3.1 pgmajfault=0i,unevictable=0i,limit=16209080320i,usage=42688512i,usage_percent=0.2633617155152699,container_id="241bcc09050d83cdd4e970f13716aa473f626cbb5e25f594870e44e4c38e6572",active_anon=4096i,inactive_file=215220224i,max_usage=0i,active_file=4096i,inactive_anon=34713600i,pgfault=7726i 1732415452000000000
```