### PR TITLE
feat: adding ethtool and interrupts plugin for mev

### DIFF
--- a/telegraf.d/telegraf.conf.bf2
+++ b/telegraf.d/telegraf.conf.bf2
@@ -20,6 +20,16 @@
   tag_keys = ["name"]
   json_query = "result.bdevs"
 
+# Interrupts Input Plugin
+[[inputs.interrupts]]
+
+# Dns query Input Plugin
+[[inputs.dns_query]]
+
+# Ethtool Input Plugin
+[[inputs.ethtool]]
+  interface_include = ["enp3s0f1s0"]
+
 # CPU Input Plugin
 [[inputs.cpu]]
   percpu = true

--- a/telegraf.d/telegraf.conf.mev
+++ b/telegraf.d/telegraf.conf.mev
@@ -7,6 +7,13 @@
 [[inputs.mem]]
   # no configuration
 
+# Interrupts Input Plugin
+[[inputs.interrupts]]
+
+# Ethtool Input Plugin
+[[inputs.ethtool]]
+  interface_include = ["enp0s1f0d2"]
+
 [[inputs.nstat]]
   # no configuration
 


### PR DESCRIPTION
for mev
```
> ethtool,driver=idpf,host=ipu-acc,interface=enp0s1f0d2 autoneg=0i,duplex=1i,interface_up=true,link=1i,rx-bad_descs=0i,rx-broadcast_pkts=0i,rx-csum_errors=0i,rx-hsplit=0i,rx-hsplit_hbo=0i,rx-length_errors=0i,rx-multicast_pkts=0i,rx-unicast_pkts=0i,rx-unknown_protocol=0i,rx_bytes=0i,rx_q-0.bytes=0i,rx_q-0.pkts=0i,rx_q-0.rx_gro_hw_pkts=0i,rx_q-1.bytes=0i,rx_q-1.pkts=0i,rx_q-1.rx_gro_hw_pkts=0i,rx_q-10.bytes=0i,rx_q-10.pkts=0i,rx_q-10.rx_gro_hw_pkts=0i,rx_q-11.bytes=0i,rx_q-11.pkts=0i,rx_q-11.rx_gro_hw_pkts=0i,rx_q-12.bytes=0i,rx_q-12.pkts=0i,rx_q-12.rx_gro_hw_pkts=0i,rx_q-13.bytes=0i,rx_q-13.pkts=0i,rx_q-13.rx_gro_hw_pkts=0i,rx_q-14.bytes=0i,rx_q-14.pkts=0i,rx_q-14.rx_gro_hw_pkts=0i,rx_q-15.bytes=0i,rx_q-15.pkts=0i,rx_q-15.rx_gro_hw_pkts=0i,rx_q-2.bytes=0i,rx_q-2.pkts=0i,rx_q-2.rx_gro_hw_pkts=0i,rx_q-3.bytes=0i,rx_q-3.pkts=0i,rx_q-3.rx_gro_hw_pkts=0i,rx_q-4.bytes=0i,rx_q-4.pkts=0i,rx_q-4.rx_gro_hw_pkts=0i,rx_q-5.bytes=0i,rx_q-5.pkts=0i,rx_q-5.rx_gro_hw_pkts=0i,rx_q-6.bytes=0i,rx_q-6.pkts=0i,rx_q-6.rx_gro_hw_pkts=0i,rx_q-7.bytes=0i,rx_q-7.pkts=0i,rx_q-7.rx_gro_hw_pkts=0i,rx_q-8.bytes=0i,rx_q-8.pkts=0i,rx_q-8.rx_gro_hw_pkts=0i,rx_q-9.bytes=0i,rx_q-9.pkts=0i,rx_q-9.rx_gro_hw_pkts=0i,speed=200000i,tx-broadcast_pkts=752682i,tx-busy_events=0i,tx-dma_errs=0i,tx-linearized_pkts=0i,tx-multicast_pkts=1354821i,tx-reinjection-timeouts=0i,tx-skb_drops=0i,tx-unicast_pkts=0i,tx_bytes=350598676i,tx_errors=0i,tx_q-0.bytes=0i,tx_q-0.lso_pkts=0i,tx_q-0.pkts=0i,tx_q-1.bytes=37333052i,tx_q-1.lso_pkts=0i,tx_q-1.pkts=602146i,tx_q-10.bytes=0i,tx_q-10.lso_pkts=0i,tx_q-10.pkts=0i,tx_q-11.bytes=0i,tx_q-11.lso_pkts=0i,tx_q-11.pkts=0i,tx_q-12.bytes=0i,tx_q-12.lso_pkts=0i,tx_q-12.pkts=0i,tx_q-13.bytes=0i,tx_q-13.lso_pkts=0i,tx_q-13.pkts=0i,tx_q-14.bytes=246127014i,tx_q-14.lso_pkts=0i,tx_q-14.pkts=752682i,tx_q-15.bytes=0i,tx_q-15.lso_pkts=0i,tx_q-15.pkts=0i,tx_q-2.bytes=12946010i,tx_q-2.lso_pkts=0i,tx_q-2.pkts=150535i,tx_q-3.bytes=0i,tx_q-3.lso_pkts=0i,tx_q-3.pkts=0i,tx_q-4.bytes=0i,tx_q-4.lso_pkts=0i,tx_q-4.pkts=0i,tx_q-5.bytes=27075960i,tx_q-5.lso_pkts=0i,tx_q-5.pkts=300844i,tx_q-6.bytes=0i,tx_q-6.lso_pkts=0i,tx_q-6.pkts=0i,tx_q-7.bytes=0i,tx_q-7.lso_pkts=0i,tx_q-7.pkts=0i,tx_q-8.bytes=27116640i,tx_q-8.lso_pkts=0i,tx_q-8.pkts=301296i,tx_q-9.bytes=0i,tx_q-9.lso_pkts=0i,tx_q-9.pkts=0i 1738579689000000000
> interrupts,device=16393\ Edge\ idpf-enp0s1f0-TxRx-9,host=ipu-acc,irq=39,type=ITS-MSI CPU0=0i,CPU1=0i,CPU10=0i,CPU11=0i,CPU12=0i,CPU13=0i,CPU14=0i,CPU15=0i,CPU2=0i,CPU3=213895i,CPU4=0i,CPU5=0i,CPU6=0i,CPU7=0i,CPU8=0i,CPU9=0i,total=213895i 1738579689000000000

```
for bf2
```
> soft_interrupts,host=bf2,irq=RCU CPU0=3029001925i,CPU1=2461760126i,CPU2=961323606i,CPU3=902651067i,CPU4=946083461i,CPU5=935957046i,CPU6=956247398i,CPU7=960456553i,total=11153481182i 1738580303000000000
> dns_query,domain=.,host=bf2,rcode=NOERROR,record_type=NS,result=success,server=8.8.8.8 query_time_ms=10.247305,rcode_value=0i,result_code=0u 1738580303000000000
> ethtool,driver=mlx5_core,host=bf2,interface=enp3s0f1s0 autoneg=1u,ch0_aff_change=0u,ch0_arm=8647225u,ch0_eq_rearm=0u,ch0_events=9062318u,ch0_force_irq=0u,ch0_poll=9054162u,ch1_aff_change=0u,ch1_arm=3789855u,ch1_eq_rearm=0u,ch1_events=3932054u,ch1_force_irq=0u,ch1_poll=3929050u,ch2_aff_change=0u,ch2_arm=4u,ch2_eq_rearm=0u,ch2_events=5u,ch2_force_irq=0u,ch2_poll=4u,ch3_aff_change=0u,ch3_arm=3u,ch3_eq_rearm=0u,ch3_events=4u,ch3_force_irq=0u,ch3_poll=3u,ch4_aff_change=0u,ch4_arm=3u,ch4_eq_rearm=0u,ch4_events=4u,ch4_force_irq=0u,ch4_poll=3u,ch5_aff_change=0u,ch5_arm=3u,ch5_eq_rearm=0u,ch5_events=4u,ch5_force_irq=0u,ch5_poll=3u,ch6_aff_change=0u,ch6_arm=8u,ch6_eq_rearm=0u,ch6_events=9u,ch6_force_irq=0u,ch6_poll=8u,ch7_aff_change=0u,ch7_arm=8u,ch7_eq_rearm=0u,ch7_events=9u,ch7_force_irq=0u,ch7_poll=8u,ch_aff_change=0u,ch_arm=0u,ch_eq_rearm=0u,ch_events=0u,ch_force_irq=0u,ch_poll=0u,duplex=1u,interface_up=true,link=1u,link_down_events_phy=0u,module_bad_shorted=0u,module_bus_stuck=0u,module_high_temp=0u,module_unplug=0u,rx0_arfs_add=0u,rx0_arfs_err=0u,rx0_arfs_expired=0u,rx0_arfs_request_in=0u,rx0_arfs_request_out=0u,rx0_buff_alloc_err=0u,rx0_bytes=4755177864u,rx0_cache_alloc=1122u,rx0_cache_busy=0u,rx0_cache_empty=0u,rx0_cache_ext=0u,rx0_cache_full=0u,rx0_cache_rdc=0u,rx0_cache_reuse=3912094u,rx0_cache_waive=0u,rx0_congst_umr=0u,rx0_cqe_compress_blks=0u,rx0_cqe_compress_pkts=0u,

```